### PR TITLE
Fix fullscreen rotation by preserving native transforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 
 ## Change Log
 
+### [2.13] - 2025-10-23
+- refresh the native video transform before applying rotations so fullscreen landscape videos turn correctly instead of squashing
+
 ### [2.12] - 2025-10-23
 - apply native video transforms before custom rotations so fullscreen landscape videos rotate correctly
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 
 ## Change Log
 
+### [2.12] - 2025-10-23
+- apply native video transforms before custom rotations so fullscreen landscape videos rotate correctly
+
 ### [2.11] - 2025-10-22
 - preserve YouTube's native transforms when applying rotation to fix distorted fullscreen playback
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 
 ## Change Log
 
+### [2.11] - 2025-10-22
+- preserve YouTube's native transforms when applying rotation to fix distorted fullscreen playback
+
 ### [2.9] - 2024-10-16
 - fix youtube html policy change
 

--- a/ytp-rotate.user.js
+++ b/ytp-rotate.user.js
@@ -2,7 +2,7 @@
 // @author          zhzLuke96
 // @name            油管视频旋转
 // @name:en         youtube player rotate
-// @version         2.10
+// @version         2.11
 // @description     油管的视频旋转插件.
 // @description:en  rotate youtube player.
 // @namespace       https://github.com/zhzLuke96/ytp-rotate
@@ -738,6 +738,7 @@
       transform: [],
     };
     $style = document.createElement("style");
+    base_transform = "";
 
     constructor() {
       this.enable();
@@ -760,6 +761,13 @@
       if (!($player instanceof HTMLElement)) {
         throw new Error("$player must be a HTMLElement");
       }
+      const computed_style = window.getComputedStyle($video);
+      const inline_transform = this.sanitize_transform($video.style.transform);
+      const computed_transform = this.sanitize_transform(
+        computed_style?.transform
+      );
+      this.base_transform = inline_transform || computed_transform || "";
+
       this.$video = $video;
       this.$player = $player;
 
@@ -830,8 +838,16 @@
       }
 
       const scaleK = this.calcScaleK();
+      const inline_transform = this.sanitize_transform(
+        this.$video?.style.transform
+      );
+      if (inline_transform) {
+        this.base_transform = inline_transform;
+      }
+      const base_transform = this.base_transform;
 
       const transform_arr = [
+        base_transform,
         `rotate(${this.status.rotate * 90}deg)`,
         `scale(${scaleK})`,
       ];
@@ -844,9 +860,30 @@
         if (this.status.rotate % 2 == 1) append_transform("rotateY(180deg)");
         else append_transform("rotateX(180deg)");
       }
-      this.styles.transform = transform_arr;
+      this.styles.transform = transform_arr.filter((text) =>
+        Boolean(text?.trim())
+      );
 
       this.updateRule();
+    }
+
+    sanitize_transform(transform) {
+      if (!transform) {
+        return "";
+      }
+      const sanitized = transform.replace(/\s*!important\s*/g, "").trim();
+      if (!sanitized || sanitized === "none") {
+        return "";
+      }
+      const normalized = sanitized.replace(/\s+/g, "");
+      const identity_matrices = [
+        "matrix(1,0,0,1,0,0)",
+        "matrix3d(1,0,0,0,0,1,0,0,0,0,1,0,0,0,0,1)",
+      ];
+      if (identity_matrices.includes(normalized)) {
+        return "";
+      }
+      return sanitized;
     }
 
     enabled = true;

--- a/ytp-rotate.user.js
+++ b/ytp-rotate.user.js
@@ -2,7 +2,7 @@
 // @author          zhzLuke96
 // @name            油管视频旋转
 // @name:en         youtube player rotate
-// @version         2.12
+// @version         2.13
 // @description     油管的视频旋转插件.
 // @description:en  rotate youtube player.
 // @namespace       https://github.com/zhzLuke96/ytp-rotate
@@ -831,6 +831,8 @@
       if (!$player || !$video) {
         throw new Error("can't find player or video element");
       }
+      this.base_transform = this.capture_base_transform();
+
       if (this.isNoneEffect()) {
         // 清空副作用
         this.updateRule("");
@@ -838,12 +840,6 @@
       }
 
       const scaleK = this.calcScaleK();
-      const inline_transform = this.sanitize_transform(
-        this.$video?.style.transform
-      );
-      if (inline_transform) {
-        this.base_transform = inline_transform;
-      }
       const transform_arr = [
         `rotate(${this.status.rotate * 90}deg)`,
         `scale(${scaleK})`,
@@ -866,6 +862,42 @@
       );
 
       this.updateRule();
+    }
+
+    capture_base_transform() {
+      const { $video, $style } = this;
+      if (!$video) {
+        return "";
+      }
+
+      const inline_transform = this.sanitize_transform($video.style.transform);
+      if (inline_transform) {
+        return inline_transform;
+      }
+
+      if (!$style?.isConnected) {
+        return this.sanitize_transform(
+          window.getComputedStyle($video).transform
+        );
+      }
+
+      const was_disabled = $style.disabled === true;
+      let computed_transform = "";
+      try {
+        $style.disabled = true;
+        computed_transform = this.sanitize_transform(
+          window.getComputedStyle($video).transform
+        );
+      } catch (error) {
+        console.error(
+          "[ytp-rotate] failed to capture native video transform",
+          error
+        );
+      } finally {
+        $style.disabled = was_disabled;
+      }
+
+      return computed_transform;
     }
 
     sanitize_transform(transform) {

--- a/ytp-rotate.user.js
+++ b/ytp-rotate.user.js
@@ -2,7 +2,7 @@
 // @author          zhzLuke96
 // @name            油管视频旋转
 // @name:en         youtube player rotate
-// @version         2.11
+// @version         2.12
 // @description     油管的视频旋转插件.
 // @description:en  rotate youtube player.
 // @namespace       https://github.com/zhzLuke96/ytp-rotate
@@ -844,10 +844,7 @@
       if (inline_transform) {
         this.base_transform = inline_transform;
       }
-      const base_transform = this.base_transform;
-
       const transform_arr = [
-        base_transform,
         `rotate(${this.status.rotate * 90}deg)`,
         `scale(${scaleK})`,
       ];
@@ -859,6 +856,10 @@
       if (this.status.vertical) {
         if (this.status.rotate % 2 == 1) append_transform("rotateY(180deg)");
         else append_transform("rotateX(180deg)");
+      }
+      const base_transform = this.base_transform;
+      if (base_transform) {
+        transform_arr.push(base_transform);
       }
       this.styles.transform = transform_arr.filter((text) =>
         Boolean(text?.trim())


### PR DESCRIPTION
## Summary
- capture the video element's existing transform and prepend it to the rotation stack so fullscreen playback keeps YouTube's native adjustments
- bump the userscript version to 2.11 and document the fix in the changelog

## Testing
- not run (userscript change)


------
https://chatgpt.com/codex/tasks/task_e_68f9105c1e2883279e78a6eea1af8bbc